### PR TITLE
WIP: DataView.prototype.{get,set}Big{Int,Uint}64

### DIFF
--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -467,9 +467,9 @@ class JSBI extends Array {
 
     const fn = function(view, byteOffset, value, littleEndian) {
       if (value.constructor !== JSBI) {
-        throw TypeError('Value needs to be BigInt ot JSBI');
+        throw TypeError('Value needs to be JSBI');
       }
-      // Set 64 byte number as two 32 byte numbers.
+      // Set 64 bit number as two 32 bit numbers.
       // The lower/higher (depending on endianess)
       // number has an offset of 4 bytes (32/8).
       const signBit = value.sign ? (1 << 31) : 0;
@@ -497,7 +497,7 @@ class JSBI extends Array {
     }
 
     const fn = function(view, byteOffset, littleEndian) {
-      // Get 64 byte number as two 32 byte numbers.
+      // Get 64 bit number as two 32 bit numbers.
       // The lower/higher (depending on endianess)
       // number has an offset of 4 bytes (32/8).
       const lowWord = viewGetFunc.call( // DataView.get{Int|Uint}32


### PR DESCRIPTION
 Ref #4 

This is a work in progress. The idea is to split one call to the 64-bit function to two calls to the 32-bit-functions. It works with unsigned integers, but currently the signed integer tests fail. I don't fully understand the differences in integer handling between JSBI and DataView and how the rounding works. Maybe someone can point me towards some explanation, or it could be more efficient if someone else implements this altogether. I don't want to add extra work for the maintainers ;) In that case feel free to close this PR.