### PR TITLE
Fix UMD bundle to support older browsers (#24)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "browsers": [
+            "last 2 versions"
+          ]
+        }
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.0.5",
   "repository": "GoogleChromeLabs/jsbi",
   "devDependencies": {
+    "@babel/preset-env": "^7.5.2",
     "eslint": "^5.4.0",
     "eslint-config-google": "^0.9.1",
     "rollup": "^0.65.0",
+    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-babel-minify": "^6.0.0"
   },
   "main": "dist/jsbi-cjs.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import babel from 'rollup-plugin-babel';
 import pkg from './package.json';
 import minify from 'rollup-plugin-babel-minify';
 
@@ -23,12 +24,23 @@ export default [
       }),
     ],
     output: [
-      // Create a browser-friendly UMD build.
-      { name: 'JSBI', file: pkg.browser, format: 'umd' },
       // Create a Node.js-friendly CommonJS build.
       { file: pkg.main, format: 'cjs' },
       // Create a JavaScript module build, for bundlers.
       { file: pkg.module, format: 'es' },
+    ],
+  },
+  {
+    input: 'jsbi.mjs',
+    plugins: [
+      babel(),
+      minify({
+        comments: false,
+      }),
+    ],
+    output: [
+      // Create a browser-friendly UMD build.
+      { name: 'JSBI', file: pkg.browser, format: 'umd' }
     ],
   },
 ];


### PR DESCRIPTION
Added babel to transpile the UMD bundle to ES5 correctly.