### PR TITLE
✨ add `notEqual` and `NE` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Most operators are replaced by method calls:
 | Bitwise “or”                | `c = a \| b`   | `c = JSBI.bitwiseOr(a, b)`        |
 | Bitwise “xor”               | `c = a ^ b`    | `c = JSBI.bitwiseXor(a, b)`       |
 | Comparison to other BigInts | `a === b`      | `JSBI.equal(a, b)`                |
+|                             | `a !== b`      | `JSBI.notEqual(a, b)`             |
 |                             | `a < b`        | `JSBI.lessThan(a, b)`             |
 |                             | `a <= b`       | `JSBI.lessThanOrEqual(a, b)`      |
 |                             | `a > b`        | `JSBI.greaterThan(a, b)`          |
@@ -84,6 +85,7 @@ Some operations are particularly interesting when you give them inputs of mixed 
 | Operation                       | native BigInts | JSBI             |
 | ------------------------------- | -------------- | ---------------- |
 | Abstract equality comparison    | `x == y`       | `JSBI.EQ(x, y)`  |
+| Generic “not equal”             | `x != y`       | `JSBI.NE(x, y)`  |
 | Generic “less than”             | `x < y`        | `JSBI.LT(x, y)`  |
 | Generic “less than or equal”    | `x <= y`       | `JSBI.LE(x, y)`  |
 | Generic “greater than”          | `x > y`        | `JSBI.GT(x, y)`  |

--- a/jsbi.d.ts
+++ b/jsbi.d.ts
@@ -25,6 +25,7 @@ export default class JSBI {
   static greaterThan(x: JSBI, y: JSBI): boolean;
   static greaterThanOrEqual(x: JSBI, y: JSBI): boolean;
   static equal(x: JSBI, y: JSBI): boolean;
+  static notEqual(x: JSBI, y: JSBI): boolean;
 
   static bitwiseAnd(x: JSBI, y: JSBI): JSBI;
   static bitwiseXor(x: JSBI, y: JSBI): JSBI;
@@ -36,4 +37,5 @@ export default class JSBI {
   static GT(x: any, y: any): boolean;
   static GE(x: any, y: any): boolean;
   static EQ(x: any, y: any): boolean;
+  static NE(x: any, y: any): boolean;
 }

--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -324,6 +324,10 @@ class JSBI extends Array {
     return true;
   }
 
+  static noEqual(x, y) {
+    return !JSBI.equal(x, y);
+  }
+
   static bitwiseAnd(x, y) {
     if (!x.sign && !y.sign) {
       return JSBI.__absoluteAnd(x, y).__trim();
@@ -506,6 +510,10 @@ class JSBI extends Array {
         return x == y;
       }
     }
+  }
+
+  static NEQ(x, y) {
+    return !JSBI.EQ(x,y)
   }
 
   // Helpers.

--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -324,7 +324,7 @@ class JSBI extends Array {
     return true;
   }
 
-  static noEqual(x, y) {
+  static notEqual(x, y) {
     return !JSBI.equal(x, y);
   }
 
@@ -512,7 +512,7 @@ class JSBI extends Array {
     }
   }
 
-  static NEQ(x, y) {
+  static NE(x, y) {
     return !JSBI.EQ(x,y)
   }
 

--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -513,7 +513,7 @@ class JSBI extends Array {
   }
 
   static NE(x, y) {
-    return !JSBI.EQ(x,y)
+    return !JSBI.EQ(x, y);
   }
 
   // Helpers.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "dev": "rollup --config rollup.config.js --watch",
-    "test": "for file in tests/*.mjs; do node --no-warnings --experimental-modules ${file}; done; set -e; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules ${file}; done",
+    "test": "for file in tests/*.mjs; do node --no-warnings --experimental-modules \"${file}\"; done; set -e; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules \"${file}\"; done",
     "pretest": "npm run build",
     "prepublish": "npm run ci",
     "lint": "eslint --fix jsbi.mjs",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "dev": "rollup --config rollup.config.js --watch",
-    "test": "for file in tests/*.mjs; do node --no-warnings --experimental-modules \"${file}\"; done; set -e; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules \"${file}\"; done",
+    "test": "for file in tests/*.mjs; do node --no-warnings --experimental-modules ${file}; done; set -e; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules ${file}; done",
     "pretest": "npm run build",
     "prepublish": "npm run ci",
     "lint": "eslint --fix jsbi.mjs",


### PR DESCRIPTION
I'm developing the [ts-bigint-transform-jsbi](https://github.com/Gaubee/ts-bigint-transform-jsbi) repository for converting the **bigint** code of Typescript into **jsbi**.
For example, it is very simple to convert `ts. SyntaxKind. EqualsEqualsEqualsToken'into `JSBI. equal'.
So I also need `JSBI. noEqual'and `JSBI. NEQ' to handle `ExclamationEqualsEqualsToken'and `ExclamationEqualsToken'.`
The two API will make the **jsbi** more easy to use. so why no 😄 .