### PR TITLE
Fix off-by-one in string parsing

### DIFF
--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -791,9 +791,12 @@ class JSBI extends Array {
       } while (!done);
     }
 
-    while (cursor !== length) {
+    if (cursor !== length) {
       if (!JSBI.__isWhitespace(current)) return null;
-      current = string.charCodeAt(cursor++);
+      for (cursor++; cursor < length; cursor++) {
+        current = string.charCodeAt(cursor);
+        if (!JSBI.__isWhitespace(current)) return null;
+      }
     }
 
     // Get result.

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -51,18 +51,18 @@ const TESTS = [
   const VALID = ['123', ' 123 ', '   123   '];
   const INVALID = ['x123', 'x 123', ' 123x', '123 x', '123  xx', '123 ?a'];
   for (const v of VALID) {
-    let result = JSBI.BigInt(v);
+    const result = JSBI.BigInt(v);
     console.assert(JSBI.equal(result, JSBI.BigInt(123)));
   }
   for (const i of INVALID) {
     try {
-      let result = JSBI.BigInt(i);
+      const result = JSBI.BigInt(i);
       throw "unreachable";
-    } catch (e) {
-      console.assert(e instanceof SyntaxError);
+    } catch (exception) {
+      console.assert(exception instanceof SyntaxError);
     }
   }
-})()
+})();
 
 function parse(string) {
   if (string.charCodeAt(0) === 0x2D) { // '-'

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -46,6 +46,24 @@ const TESTS = [
   },
 ];
 
+// https://github.com/GoogleChromeLabs/jsbi/issues/36
+(function() {
+  const VALID = ['123', ' 123 ', '   123   '];
+  const INVALID = ['x123', 'x 123', ' 123x', '123 x', '123  xx', '123 ?a'];
+  for (const v of VALID) {
+    let result = JSBI.BigInt(v);
+    console.assert(JSBI.equal(result, JSBI.BigInt(123)));
+  }
+  for (const i of INVALID) {
+    try {
+      let result = JSBI.BigInt(i);
+      throw "unreachable";
+    } catch (e) {
+      console.assert(e instanceof SyntaxError);
+    }
+  }
+})()
+
 function parse(string) {
   if (string.charCodeAt(0) === 0x2D) { // '-'
     const result = JSBI.BigInt(string.slice(1));


### PR DESCRIPTION
When there was whitespace and then a single character of non-whitespace
trailing garbage after the BigInt, we failed to look at that last character.

Fixes #36.