### PR TITLE
Use unaryMinus directly instead of internal implementation

### DIFF
--- a/tests/as-int-n.mjs
+++ b/tests/as-int-n.mjs
@@ -284,9 +284,7 @@ const uintn_data = [
 
 function parse(string) {
   if (string.charCodeAt(0) === 0x2D) { // '-'
-    const result = JSBI.BigInt(string.slice(1));
-    result.sign = true;
-    return result;
+    return JSBI.unaryMinus(JSBI.BigInt(string.slice(1)));
   }
   return JSBI.BigInt(string);
 }

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -66,9 +66,7 @@ const TESTS = [
 
 function parse(string) {
   if (string.charCodeAt(0) === 0x2D) { // '-'
-    const result = JSBI.BigInt(string.slice(1));
-    result.sign = true;
-    return result;
+    return JSBI.unaryMinus(JSBI.BigInt(string.slice(1)));
   }
   return JSBI.BigInt(string);
 }


### PR DESCRIPTION
I noticed the tests are using internal implementation knowledge for negation rather than the public interface. 