### PR TITLE
Fix signedRightShift (#57)

### DIFF
--- a/jsbi.mjs
+++ b/jsbi.mjs
@@ -1720,6 +1720,8 @@ class JSBI extends Array {
     }
     let result = new JSBI(resultLength, sign);
     if (bitsShift === 0) {
+      // Zero out any overflow digit (see "roundingCanOverflow" above).
+      result.__setDigit(resultLength - 1, 0);
       for (let i = digitShift; i < length; i++) {
         result.__setDigit(i - digitShift, x.__digit(i));
       }

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -56,6 +56,12 @@ const TESTS = [
     b: '-0b1111111111111111111111111111111111111111111111111111111111111111',
     expected: '-0b1111111111111111111111111111111111111111111111111111111111111111',
   },
+  {  // https://github.com/GoogleChromeLabs/jsbi/issues/57
+    operation: 'signedRightShift',
+    a: '-0xFFFFFFFFFFFFFFFF',
+    b: '32',
+    expected: '-0x100000000',
+  },
 ];
 
 // https://github.com/GoogleChromeLabs/jsbi/issues/36


### PR DESCRIPTION
When the required rounding down of a negative number caused
overflow to a new digit, this digit was uninitialized.

Equivalent fix in V8:
https://chromium-review.googlesource.com/c/v8/v8/+/2561618