### PR TITLE
Restore pre-TypeScript migration export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,14 +32,14 @@ export default [
       {
         file: pkg.main,
         format: 'cjs',
-        exports: 'named',
+        exports: 'default',
         sourcemap: true,
       },
       // Create a JavaScript module build, for bundlers.
       {
         file: pkg.module,
         format: 'es',
-        exports: 'named',
+        exports: 'default',
         sourcemap: true,
       },
     ],


### PR DESCRIPTION
As part of the TypeScript migration in #67 we accidentally made the CommonJS bundle have a `default` export, which wasn’t the case before.

This patch fixes the Rollup configuration to restore the old behavior of `module.export = JSBI`.

Docs: https://rollupjs.org/guide/en/#outputexports

Issue: #68, #67