### PR TITLE
Fix primitive coercion on platforms that don't support Symbol.toPrimitive.

### DIFF
--- a/lib/jsbi.ts
+++ b/lib/jsbi.ts
@@ -1761,11 +1761,14 @@ class JSBI extends Array {
   static __toPrimitive(obj: any, hint='default'): any {
     if (typeof obj !== 'object') return obj;
     if (obj.constructor === JSBI) return obj;
-    const exoticToPrim = obj[Symbol.toPrimitive];
-    if (exoticToPrim) {
-      const primitive = exoticToPrim(hint);
-      if (typeof primitive !== 'object') return primitive;
-      throw new TypeError('Cannot convert object to primitive value');
+    if (typeof Symbol !== 'undefined' &&
+          typeof Symbol.toPrimitive === 'symbol') {
+      const exoticToPrim = obj[Symbol.toPrimitive];
+      if (exoticToPrim) {
+        const primitive = exoticToPrim(hint);
+        if (typeof primitive !== 'object') return primitive;
+        throw new TypeError('Cannot convert object to primitive value');
+      }
     }
     const valueOf = obj.valueOf;
     if (valueOf) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc && for f in tsc-out/*.js; do mv -- \"$f\" \"${f%.js}.mjs\"; done && rollup --config rollup.config.js",
     "dev": "rollup --config rollup.config.js --watch",
-    "test": "for file in tests/*.mjs; do node --no-warnings --experimental-modules --experimental-specifier-resolution=node --loader ./tests/resolve.source.mjs \"${file}\"; done; set -e; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules --experimental-specifier-resolution=node --loader ./tests/resolve.source.mjs \"${file}\"; done",
+    "test": "set -e; for file in tests/*.mjs; do node --no-warnings --experimental-modules --experimental-specifier-resolution=node --loader ./tests/resolve.source.mjs \"${file}\"; done; for file in benchmarks/*.mjs; do node --no-warnings --experimental-modules --experimental-specifier-resolution=node --loader ./tests/resolve.source.mjs \"${file}\"; done",
     "pretest": "npm run build",
     "prepublish": "npm run ci",
     "lint": "eslint . --ext ts --fix",

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -46,6 +46,22 @@ import JSBI from '../jsbi';
   console.assert(JSBI.EQ(JSBI.BigInt(18014398509481980), 18014398509481980));
   console.assert(JSBI.EQ(JSBI.BigInt(18014398509481982), 18014398509481982));
   console.assert(JSBI.EQ(JSBI.BigInt(18014398509481988), 18014398509481988));
+
+  // Emulate an environment that doesn't have Symbol (e.g. IE11)
+  // and make sure we can still coerce to primitive values.
+  // See #74.
+ const globalSymbol = globalThis.Symbol;
+  try {
+    globalThis.Symbol = undefined;
+    console.assert(JSBI.EQ(JSBI.BigInt(0x7FFFFFFF), {
+      valueOf: () => 0x7FFFFFFF,
+    }));
+    console.assert(JSBI.LT(JSBI.BigInt(0x7FFFFFF0), {
+      valueOf: () => 0x7FFFFFFF,
+    }));
+  } finally {
+    globalThis.Symbol = globalSymbol;
+  }
 }
 
 const TESTS = [


### PR DESCRIPTION
Fixes #74.