### PR TITLE
Use Node assertions in tests.

### DIFF
--- a/tests/as-int-n.mjs
+++ b/tests/as-int-n.mjs
@@ -1,5 +1,5 @@
 import JSBI from '../jsbi';
-import { strict as assert } from 'assert';
+import { assertTrue } from './assert';
 
 const intn_data = [
   {expected: '-1', n: 3, x: '15'},
@@ -296,7 +296,7 @@ for (const test of intn_data) {
   const x = parse(test.x);
   const expected = parse(test.expected);
   const result = JSBI.asIntN(test.n, x);
-  assert(JSBI.equal(expected, result),
+  assertTrue(JSBI.equal(expected, result),
     `Unexpected result for asIntN(${test.n}, ${ test.x }):
     Expected: ${ test.expected }
     Actual:   ${ result.toString() }`.trim());
@@ -306,7 +306,7 @@ for (const test of uintn_data) {
   const x = parse(test.x);
   const expected = parse(test.expected);
   const result = JSBI.asUintN(test.n, x);
-  assert(JSBI.equal(expected, result),
+  assertTrue(JSBI.equal(expected, result),
     `Unexpected result for asUintN(${test.n}, ${ test.x }):
     Expected: ${ test.expected }
     Actual:   ${ result.toString() }`.trim());

--- a/tests/assert.mjs
+++ b/tests/assert.mjs
@@ -1,0 +1,7 @@
+export function assertEqual(a, b, message) {
+  if (a !== b) throw new Error(message);
+}
+
+export function assertTrue(x, message) {
+  if (!x) throw new Error(message);
+}

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import JSBI from '../jsbi';
-import { strict as assert } from 'assert';
+import { assertEqual, assertTrue } from './assert';
 
 {
   // Test the example from the README.
@@ -21,32 +21,32 @@ import { strict as assert } from 'assert';
   const other = JSBI.BigInt(2);
   const result = JSBI.add(max, other);
   // → 9007199254740993
-  assert.equal('9007199254740993', result.toString());
+  assertEqual('9007199254740993', result.toString());
   // Test `JSBI.toNumber` as well.
-  assert.equal(9007199254740993, JSBI.toNumber(result));
+  assertEqual(9007199254740993, JSBI.toNumber(result));
 
   // Corner cases near the single digit threshold.
-  assert(JSBI.LT(JSBI.BigInt('0x100000000'), 0x100000001));
-  assert(JSBI.EQ(JSBI.BigInt('0xFFFFFFFF'), 0xFFFFFFFF));
-  assert(JSBI.EQ(JSBI.BigInt('0x7FFFFFFF'), 0x7FFFFFFF));
-  assert(JSBI.EQ(JSBI.BigInt(0x7FFFFFFF), 0x7FFFFFFF));
-  assert(JSBI.EQ(JSBI.BigInt(-0x7FFFFFFF), -0x7FFFFFFF));
-  assert(JSBI.LT(JSBI.BigInt(0x7FFFFFF0), 0x7FFFFFFF));
-  assert(JSBI.GT(JSBI.BigInt(-0x7FFFFFF0), -0x7FFFFFFF));
+  assertTrue(JSBI.LT(JSBI.BigInt('0x100000000'), 0x100000001));
+  assertTrue(JSBI.EQ(JSBI.BigInt('0xFFFFFFFF'), 0xFFFFFFFF));
+  assertTrue(JSBI.EQ(JSBI.BigInt('0x7FFFFFFF'), 0x7FFFFFFF));
+  assertTrue(JSBI.EQ(JSBI.BigInt(0x7FFFFFFF), 0x7FFFFFFF));
+  assertTrue(JSBI.EQ(JSBI.BigInt(-0x7FFFFFFF), -0x7FFFFFFF));
+  assertTrue(JSBI.LT(JSBI.BigInt(0x7FFFFFF0), 0x7FFFFFFF));
+  assertTrue(JSBI.GT(JSBI.BigInt(-0x7FFFFFF0), -0x7FFFFFFF));
 
   // Regression test for issue #63.
-  assert.equal(
+  assertEqual(
       JSBI.BigInt(4.4384296245614243e+42).toString(),
       '4438429624561424320047307980392507864252416');
   const str = '3361387880631608742970259577528807057005903';
-  assert.equal(JSBI.toNumber(JSBI.BigInt(str)), 3.361387880631609e+42);
+  assertEqual(JSBI.toNumber(JSBI.BigInt(str)), 3.361387880631609e+42);
 
   // Regression test for issue #72.
-  assert(JSBI.EQ(max, Number.MAX_SAFE_INTEGER));
+  assertTrue(JSBI.EQ(max, Number.MAX_SAFE_INTEGER));
 
-  assert(JSBI.EQ(JSBI.BigInt(18014398509481980), 18014398509481980));
-  assert(JSBI.EQ(JSBI.BigInt(18014398509481982), 18014398509481982));
-  assert(JSBI.EQ(JSBI.BigInt(18014398509481988), 18014398509481988));
+  assertTrue(JSBI.EQ(JSBI.BigInt(18014398509481980), 18014398509481980));
+  assertTrue(JSBI.EQ(JSBI.BigInt(18014398509481982), 18014398509481982));
+  assertTrue(JSBI.EQ(JSBI.BigInt(18014398509481988), 18014398509481988));
 
   // Emulate an environment that doesn't have Symbol (e.g. IE11)
   // and make sure we can still coerce to primitive values.
@@ -54,10 +54,10 @@ import { strict as assert } from 'assert';
  const globalSymbol = globalThis.Symbol;
   try {
     globalThis.Symbol = undefined;
-    assert(JSBI.EQ(JSBI.BigInt(0x7FFFFFFF), {
+    assertTrue(JSBI.EQ(JSBI.BigInt(0x7FFFFFFF), {
       valueOf: () => 0x7FFFFFFF,
     }));
-    assert(JSBI.LT(JSBI.BigInt(0x7FFFFFF0), {
+    assertTrue(JSBI.LT(JSBI.BigInt(0x7FFFFFF0), {
       valueOf: () => 0x7FFFFFFF,
     }));
   } finally {
@@ -66,10 +66,10 @@ import { strict as assert } from 'assert';
 
   try {
     +JSBI.BigInt(0x7FFFFFFF);
-    assert(false, 'coercion of JSBI instances via valueOf should throw.');
+    assertTrue(false, 'coercion of JSBI instances via valueOf should throw.');
   } catch (error) {
-    assert(error instanceof Error);
-    assert.equal(error.message, 'Convert JSBI instances to native numbers using `toNumber`.');
+    assertTrue(error instanceof Error);
+    assertEqual(error.message, 'Convert JSBI instances to native numbers using `toNumber`.');
   }
 }
 
@@ -119,14 +119,14 @@ const TESTS = [
                    '-0o0', '-0x0', '-0b0', '-0x1'];
   for (const v of VALID) {
     const result = JSBI.BigInt(v);
-    assert(JSBI.equal(result, JSBI.BigInt(123)));
+    assertTrue(JSBI.equal(result, JSBI.BigInt(123)));
   }
   for (const i of INVALID) {
     try {
       const result = JSBI.BigInt(i);
       throw "unreachable";
     } catch (exception) {
-      assert(exception instanceof SyntaxError);
+      assertTrue(exception instanceof SyntaxError);
     }
   }
 })();
@@ -153,7 +153,7 @@ for (const test of TESTS) {
   const b = parse(test.b);
   const expected = parse(test.expected);
   const result = JSBI[operation](a, b);
-  assert(
+  assertTrue(
     JSBI.equal(result, expected),
     `
       Unexpected result.


### PR DESCRIPTION
Console.assert in tests no longer throw exceptions: https://github.com/nodejs/node/commit/15d880bcb62c628f1e7c3cc7baf659a63b312c7c

Throwing errors means that failed assertions will halt the github workflows, and so failing tests should now correctly show up on the GitHub UI as failed (where I don't think they would have before?).

This also adds a check that the valueOf function added in #78 is the cause of the coercion error by checking the message.