### PR TITLE
Fix prototype when extending Array.

### DIFF
--- a/lib/jsbi.ts
+++ b/lib/jsbi.ts
@@ -14,6 +14,9 @@
 class JSBI extends Array {
   constructor(length: number, private sign: boolean) {
     super(length);
+    // Explicitly set the prototype as per 
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, JSBI.prototype);
     if (length > JSBI.__kMaxLength) {
       throw new RangeError('Maximum BigInt size exceeded');
     }


### PR DESCRIPTION
Extending array is unusual (the returned value from `Array.call(x, size)` doesn't have x's prototype, only the Array prototype), and various transpilers need to work around this. TypeScript's transpilation does not, and they don't intend to, telling users to work around this in code.

This is one of the issues with the UMD build in #79, but this alone won't fix it as the rollup config doesn't emit ES5 code. This I'll look into separately.